### PR TITLE
Improved to latest version of Swift and tested on iOS 16

### DIFF
--- a/ZoneSharing/ViewModels/ViewModel.swift
+++ b/ZoneSharing/ViewModels/ViewModel.swift
@@ -83,7 +83,7 @@ final class ViewModel: ObservableObject {
             try await database.save(zone)
             
             let id = CKRecord.ID(zoneID: zone.zoneID)
-            let contactRecord = CKRecord(recordType: "Contact", recordID: id)
+            let contactRecord = CKRecord(recordType: "SharedContact", recordID: id)
             contactRecord["name"] = name
             contactRecord["phoneNumber"] = phoneNumber
 

--- a/ZoneSharing/Views/ContentView.swift
+++ b/ZoneSharing/Views/ContentView.swift
@@ -154,7 +154,7 @@ struct ContentView_Previews: PreviewProvider {
             id: UUID().uuidString,
             name: "John Appleseed",
             phoneNumber: "(888) 555-5512",
-            associatedRecord: CKRecord(recordType: "Contact")
+            associatedRecord: CKRecord(recordType: "SharedContact")
         )
     ]
 


### PR DESCRIPTION
Changed name of record field to allow test along other ck samples (which may use same field but with different payload type).